### PR TITLE
fix: hostname

### DIFF
--- a/initiator.go
+++ b/initiator.go
@@ -60,7 +60,7 @@ func createContainer(config ContainerConfig, prober Probe) (*Instance, error) {
 		return nil, err
 	}
 
-	host := fmt.Sprintf("%s:%d", "localhost", getHostPort(container, config.ContainerPort))
+	host := fmt.Sprintf("%s:%d", "127.0.0.1", getHostPort(container, config.ContainerPort))
 
 	instance := &Instance{
 		client,

--- a/initiator_test.go
+++ b/initiator_test.go
@@ -93,7 +93,7 @@ func TestGetHost(t *testing.T) {
 		assert.NoError(t, instance.Stop())
 	}()
 
-	assert.Regexp(t, regexp.MustCompile("^localhost:\\d+$"), instance.GetHost())
+	assert.Regexp(t, regexp.MustCompile("^127.0.0.1:\\d+$"), instance.GetHost())
 }
 
 func TestClearObsolete(t *testing.T) {


### PR DESCRIPTION
Since mysql defaults to socket connections with the hostname `localhost` we should return `127.0.0.1` so that TCP is forced