### PR TITLE
fix: unexpected EOF error

### DIFF
--- a/probe.go
+++ b/probe.go
@@ -78,6 +78,8 @@ func (i MysqlProbe) DoProbe(instance *Instance) error {
 		return err
 	}
 
+	db.SetMaxIdleConns(0)
+
 	var version string
 	err = db.QueryRow("SELECT VERSION()").Scan(&version)
 	if err != nil && err != sql.ErrNoRows {


### PR DESCRIPTION
As per the documentation: https://golang.org/pkg/database/sql/#DB.SetMaxIdleConns

This wont keep any Idle connections open. And will silence the error we are getting whilst probing for the DB.

Tested and it seems to work