### PR TITLE
fix: Repair broken links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Useful for testing.
 
 This library currently supports the following services out of the box:
 
-- [pubsub](pubsub.go)
-- [mysql](mysql.go)
+- [pubsub](pubsub/pubsub.go)
+- [mysql](mysql/mysql.go)
 
 ## Installation
 


### PR DESCRIPTION
The package links in the README are broken because they don't point to files that exist, so I fixed that very minor issue 🔨