### PR TITLE
Use mysql:5.7 as default MySQL image

### DIFF
--- a/mysql/mysql.go
+++ b/mysql/mysql.go
@@ -18,7 +18,7 @@ type MysqlInstance struct {
 }
 
 var (
-	DefaultImage = "storytel/mysql-57-test"
+	DefaultImage = "mysql:5.7"
 
 	defaultCmd = []string{}
 


### PR DESCRIPTION
The storytel/mysql-57-test doesn't run on Apple Silicon.
There's no difference between the default image and our test image
besides [some configuration for memory][1] which I'm not sure
is better anyway.

[1]: https://github.com/Storytel/docker-initiator-images/blob/master/mysql-57-test/test.cnf